### PR TITLE
fixes and improvements

### DIFF
--- a/casm.js
+++ b/casm.js
@@ -10,11 +10,11 @@ function assemble(circuit, currentDir) {
   currentDir = currentDir == null ? '' : currentDir;
 
   // handle macros
-  let counter = circuit.wires;
   let gates = [];
+  let parsedGates = [];
   for (let i = 0; i < circuit.gate.length; i++) {
     // case 1: plain gate
-    let plainGates = ['AND', 'OR', 'INV'];
+    let plainGates = ['AND', 'XOR', 'INV'];
     if (plainGates.indexOf(circuit.gate[i].type) > -1) {
       gates.push(circuit.gate[i]);
       continue;
@@ -30,24 +30,72 @@ function assemble(circuit, currentDir) {
       parsed = parser.parse(fs.readFileSync(nestedpath, 'utf8'));
     }
 
-    const result = macro.renameAndDump(circuit.gate[i], parsed, counter);
-    gates = gates.concat(result.gate);
-    counter += result.wires;
+    parsedGates.push({ 'parsed': parsed, 'index': i });
   }
-  circuit.gate = gates;
+
+  //calculate the total amount of intermediate wires inside nested circuits
+  let intermediateWires = 0
+  for (let i = 0; i < parsedGates.length; i++) {
+    let parsed = parsedGates[i].parsed;
+    intermediateWires += (parsed.wires - parsed.inputs.length - parsed.outputs.length);
+  }
+  // find circuit outputs in inputs/outputs of gates and shift them 
+  // to the very end of the new wires range
+  const outputRange = [];
+  for (let i = circuit.wires - circuit.outputs.length; i < circuit.wires; i++) {
+    outputRange.push(i);
+  }
+  for (let i = 0; i < circuit.gate.length; i++) {
+    const inputs = circuit.gate[i].inputs;
+    for (let j = 0; j < inputs.length; j++) {
+      if (outputRange.indexOf(inputs[j]) > -1) {
+        circuit.gate[i].inputs[j] = inputs[j] + intermediateWires;
+      }
+    }
+    const outputs = circuit.gate[i].outputs;
+    for (let k = 0; k < outputs.length; k++) {
+      if (outputRange.indexOf(outputs[k]) > -1) {
+        circuit.gate[i].outputs[k] = outputs[k] + intermediateWires;
+      }
+    }
+  }
+
+  // shift all nested circuits' intermediate wires to the new offset
+  // not touching the plain gates - they remain at their offsets
+  var offset = circuit.wires - circuit.outputs.length; // start where circuit outputs originally were
+  for (let i = 0; i < parsedGates.length; i++) {
+    const parsed = parsedGates[i].parsed;
+    const idx = parsedGates[i].index;
+    const shiftBy = offset - circuit.gate[idx].inputs.length;
+    const result = macro.renameAndDump(circuit.gate[idx], parsed, shiftBy);
+    gates.splice(idx, 0, result.gate);
+    offset += (result.wires - result.inputs.length - result.outputs.length);
+  }
+
+  // flatten gates
+  circuit.gate = [].concat.apply([], gates);
 
   // update meta data
   circuit.gates = circuit.gate.length;
+  circuit.wires = circuit.wires + intermediateWires;
+  circuit.outputs = circuit.outputs.map(i => i + intermediateWires);
 
-  const newOutputs = circuit.outputs.map(i => i + counter);
-  circuit.wires = Math.max.apply(null, newOutputs) + 1;
-  macro.renameOutputs(circuit.outputs, newOutputs, circuit.gate);
-  circuit.outputs = newOutputs;
-
-  macro.removeGaps(circuit);
-
+  //check if any gaps exist
+  const real = {};
+  for (let g of circuit.gate) {
+    for (let w of g.inputs.concat(g.outputs)) {
+      real[w] = true;
+    }
+  }
+  for (let i = 0; i < circuit.wires; i++) {
+    if (!real[i]) {
+      console.log('gap at position:', i);
+      throw ('Error: gap detected');
+    }
+  }
   return circuit;
 }
+
 
 function parseAndAssemble(inputPath) {
   const inputCircuit = parser.parse(fs.readFileSync(inputPath, 'utf8'));

--- a/macro.js
+++ b/macro.js
@@ -33,44 +33,7 @@ function renameOutputs(currentOutputs, newOutputs, gates) {
   }
 }
 
-function removeGaps(circuit) {
-  const real = {};
-  for (let g of circuit.gate) {
-    for (let w of g.inputs.concat(g.outputs)) {
-      real[w] = true;
-    }
-  }
-
-  const rename = {};
-  let first_gap = null;
-  for (let i = 0; i < circuit.wires; i++) {
-    if (real[i]) {
-      if (first_gap != null) {
-        rename[i] = first_gap;
-        first_gap++;
-      }
-    } else if (first_gap == null) {
-      first_gap = i;
-    }
-  }
-
-  circuit.wires = first_gap;
-  for (let g of circuit.gate) {
-    for (let i = 0; i < g.inputs.length; i++) {
-      if (rename[g.inputs[i]] != null) {
-        g.inputs[i] = rename[g.inputs[i]];
-      }
-    }
-    for (let i = 0; i < g.outputs.length; i++) {
-      if (rename[g.outputs[i]] != null) {
-        g.outputs[i] = rename[g.outputs[i]];
-      }
-    }
-  }
-}
-
 module.exports = {
   renameAndDump: renameAndDump,
-  renameOutputs: renameOutputs,
-  removeGaps: removeGaps
+  renameOutputs: renameOutputs
 };

--- a/parser.js
+++ b/parser.js
@@ -48,6 +48,11 @@ function parse(text) {
           range_ = range(+range_[0], +range_[0] + +range_[1] - 1, 1);
           line = line.splice(0, j).concat(range_, line.slice(1));
           j += range_.length - 1;
+        } else if (range_.indexOf('*') > -1) {
+          range_ = range_.split('*');
+          range_ = Array(Number(range_[1])).fill(range_[0]);
+          line = line.splice(0, j).concat(range_, line.slice(1));
+          j += range_.length - 1;
         }
       }
     }


### PR DESCRIPTION
 - add XOR to list of gates 
- assemble by shifting nested wires to the end. This has the added benefit that
   there will be no gaps. Thus we can treat gaps as a sign of an error in circuit design.
 - introduce a * operator [123*64] means repeat 123 64 times. This is especially useful
   when 0-padding last chunk of sha256 where lots of zeroes are required.

This PR addresses  https://github.com/wyatt-howe/macro-circuit-assembler/issues/2 and https://github.com/wyatt-howe/macro-circuit-assembler/issues/1